### PR TITLE
Remove react preset from .compilerc

### DIFF
--- a/.compilerc
+++ b/.compilerc
@@ -3,8 +3,7 @@
     "development": {
       "application/javascript": {
         "presets": [
-          ["env", { "targets": { "electron": 1.4 } }],
-          "react"
+          ["env", { "targets": { "electron": 1.4 } }]
         ],
         "plugins": ["transform-async-to-generator"],
         "sourceMaps": "inline"
@@ -13,8 +12,7 @@
     "production": {
       "application/javascript": {
         "presets": [
-          ["env", { "targets": { "electron": 1.4 } }],
-          "react"
+          ["env", { "targets": { "electron": 1.4 } }]
         ],
         "plugins": ["transform-async-to-generator"],
         "sourceMaps": "none"


### PR DESCRIPTION
TBH I don't know what this does exactly but I need that change in order for electron to run with `build/main.js`. If the react line is present in that file, I'd get the following error:

```
A JavaScript error occurred in the main process
Uncaught Exception:
Error: Couldn't find preset "react" relative to directory "syncrypt/elm-desktop/build"
```
